### PR TITLE
Add request routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "typescript": "4.0.3"
   },
   "dependencies": {
+    "find-my-way": "3.0.4",
     "pino": "6.7.0",
     "yargs": "16.0.3"
   }

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,18 +1,51 @@
 import {Http2ServerRequest, Http2ServerResponse} from 'http2';
+
 import { Logger } from 'pino';
+
 import { OnRequestHandler } from './http2/server';
 
-function makeAppHandler(log: Logger): OnRequestHandler {
+/**
+ * Why introduce a new type when we could just use the
+ * `Router.Instance<HTTPVersion.V2>` type that is returned
+ * by `makeRouter()`?
+ *
+ * The type is from the 'find-my-way` package and I want
+ * to minimise how much our application layer is coupled
+ * to external dependencies.
+ *
+ * A simpler reason is: why should it? The App handler
+ * only needs a router with a "lookup" method, it doesn't
+ * need everything else on `Router.Instance` so why should
+ * it couple itself to it?
+ *
+ * Not doing so also makes testing easier, rather than
+ * constructing something that includes everything in
+ * `Router.Instance` we can create a simple mock
+ * router like `{ lookup: (req, res): void => {...} }`
+ */
+export interface AppRouter<Context> {
+  lookup<Context>(
+    req: Http2ServerRequest,
+    res: Http2ServerResponse,
+    ctx?: Context
+  ): void;
+}
+
+/**
+ * Returns a new request handler that can be plugged into our HTTP2 Server.
+ *
+ * It accepts a router
+ */
+function makeAppHandler<Context>(
+  router: AppRouter<Context>,
+  log: Logger,
+): OnRequestHandler {
   return (
-    request: Http2ServerRequest, 
-    response: Http2ServerResponse,
+    req: Http2ServerRequest,
+    res: Http2ServerResponse,
   ): void => {
-    response.writeHead(200, {
-      'content-type': 'text/html; charset=utf-8',
-    });
-  
-    response.end('<h1>Hello World</h1>');
-  };  
-} 
+    router.lookup(req, res);
+  };
+}
 
 export default makeAppHandler;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import createAndListen from './http2/server';
 import makeAppHandler from './app';
 import applyLoggingToRequestHandler, { makeRequestIDGenerator } from './http2/applyLoggingToRequestHandler';
 import makeLog from './logging/makeLog';
+import makeRouter from './makeRouter';
 
 export interface Options {
   keyPath: string;
@@ -18,7 +19,14 @@ function init({host, port, keyPath, certPath}: Options): void {
   const privateKey = readFileSync(keyPath).toString();
   const cert = readFileSync(certPath).toString();
 
-  const appHandler = makeAppHandler(log);
+  const router = makeRouter();
+
+  router.on('GET', '/', (req, res, params) => {
+    res.setHeader('content-type',  'application/json; charset=utf-8');
+    res.end('{"message":"hello world"}')
+  });
+
+  const appHandler = makeAppHandler(router, log);
   const nextReqID = makeRequestIDGenerator();
   const requestHandler = applyLoggingToRequestHandler(log, nextReqID, appHandler);
 

--- a/src/makeRouter.ts
+++ b/src/makeRouter.ts
@@ -1,0 +1,50 @@
+import {Http2ServerRequest, Http2ServerResponse} from 'http2';
+
+import Router, {HTTPVersion} from 'find-my-way';
+
+export type DefaultRoute = (req: Http2ServerRequest, res: Http2ServerResponse) => void;
+export type OnBadUrlRoute = (path: string, req: Http2ServerRequest, res: Http2ServerResponse) => void;
+
+/**
+ * The default default route :-)
+ */
+const defaultDefaultRoute = (req: Http2ServerRequest, res: Http2ServerResponse): void => {
+  res.statusCode = 404
+  res.end()
+};
+
+/**
+ * The default onBadUrl route
+ */
+const defaultOnBadUrlRoute = (path: string, req: Http2ServerRequest, res: Http2ServerResponse): void => {
+  res.statusCode = 400
+  res.end(`Bad path: ${path}`)
+};
+
+interface RouterOptions {
+  defaultRoute?: DefaultRoute;
+  onBadUrl: OnBadUrlRoute;
+}
+
+const defaultOptions = Object.freeze({
+  defaultRoute: defaultDefaultRoute,
+  onBadUrl: defaultOnBadUrlRoute,
+});
+
+/**
+ * Constructs the default router which sets some default behaviour, which
+ * can be overidden by supplying different options.
+ */
+export default function makeRouter(
+  options: Partial<RouterOptions> = {},
+): Router.Instance<HTTPVersion.V2> {
+  const {
+    defaultRoute,
+    onBadUrl,
+  } = Object.assign({}, defaultOptions, options);
+
+  return Router<HTTPVersion.V2>({
+    defaultRoute,
+    onBadUrl,
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2560,6 +2560,11 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
+fast-decode-uri-component@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz#46f8b6c22b30ff7a81357d4f59abfae938202543"
+  integrity sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==
+
 fast-deep-equal@^3.1.1:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -2639,6 +2644,15 @@ fill-range@^7.0.1:
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
+
+find-my-way@3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/find-my-way/-/find-my-way-3.0.4.tgz#a485973d1a3fdafd989ac9f12fd2d88e83cda268"
+  integrity sha512-Trl/mNAVvTgCpo9ox6yixkwiZUvecKYUQZoAuMCBACsgGqv+FbWe+jE5sBA5+U8LIWrJk/cw8zPV53GPrjTnsw==
+  dependencies:
+    fast-decode-uri-component "^1.0.1"
+    safe-regex2 "^2.0.0"
+    semver-store "^0.3.0"
 
 find-up@^2.0.0, find-up@^2.1.0:
   version "2.1.0"
@@ -4856,6 +4870,11 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
+ret@~0.2.0:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/ret/-/ret-0.2.2.tgz#b6861782a1f4762dce43402a71eb7a283f44573c"
+  integrity sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==
+
 reusify@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
@@ -4895,6 +4914,13 @@ safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
+safe-regex2@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/safe-regex2/-/safe-regex2-2.0.0.tgz#b287524c397c7a2994470367e0185e1916b1f5b9"
+  integrity sha512-PaUSFsUaNNuKwkBijoAPHAK6/eM6VirvyPWlZ7BAQy4D+hCvh4B6lIG+nPdhbFfIbP+gTGBcrdsOaUs0F+ZBOQ==
+  dependencies:
+    ret "~0.2.0"
+
 safe-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/safe-regex/-/safe-regex-1.1.0.tgz#40a3669f3b077d1e943d44629e157dd48023bf2e"
@@ -4928,6 +4954,11 @@ saxes@^5.0.0:
   integrity sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==
   dependencies:
     xmlchars "^2.2.0"
+
+semver-store@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/semver-store/-/semver-store-0.3.0.tgz#ce602ff07df37080ec9f4fb40b29576547befbe9"
+  integrity sha512-TcZvGMMy9vodEFSse30lWinkj+JgOBvPn8wRItpQRSayhc+4ssDs335uklkfvQQJgL/WvmHLVj4Ycv2s7QCQMg==
 
 "semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"


### PR DESCRIPTION
## Description
This PR adds a `makeRouter()` helper that allows routes
and handlers to be declared. This is using the `find-my-way`
package under the covers.

* The default and badUrl route behaviour can be defined but
the defaults are 404 and 400 respectively
* A router get's passed to the makeAppHandler, it takes a
simplified version of the Router interface for easy testing
* The app tests have been updated

## Motivation and Context
Routing behaviour could have been implemented directly in the app handler
but it would have got very messy as the number and complexity of routed
increased.

Additionally, I don't actually want to write something to do the route
matching as there's many existing routers. [Find My Way](https://github.com/delvedor/find-my-way/)
is simple, well tested, and efficient. so it seems like a good choice

## How Has This Been Tested?
Via the updated app tests and manually by running the server locally and
making requests with Curl

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
